### PR TITLE
new metamethod __len,__pairs,__ipairs in lua 5.2

### DIFF
--- a/middleclass.lua
+++ b/middleclass.lua
@@ -96,9 +96,9 @@ end
 
 local Object = _createClass("Object", nil)
 
-Object.static.__metamethods = { '__add', '__call', '__concat', '__div', '__le', '__lt',
-                                '__mod', '__mul', '__pow', '__sub', '__tostring', '__unm',
-                                '__len','__pairs','__ipairs'}
+Object.static.__metamethods = { '__add', '__call', '__concat', '__div', '__ipairs', '__le',
+                                '__len', '__lt', '__mod', '__mul', '__pairs', '__pow', '__sub',
+                                '__tostring', '__unm'}
 
 function Object.static:allocate()
   assert(type(self) == 'table', "Make sure that you are using 'Class:allocate' instead of 'Class.allocate'")


### PR DESCRIPTION
`__len`,`__pairs`,`__ipairs` has been released in lua 5.2.  
I have test these three  metamethod in middleclass, it can work correctly.  
Please consider merge this branch into master . Thanks
