### PR TITLE
Stubless inheritable metamethods + __gc, __mode, __metatable

### DIFF
--- a/middleclass.lua
+++ b/middleclass.lua
@@ -35,7 +35,7 @@ local function _setClassDictionariesMetatables(aClass)
   local super = aClass.super
   if super then
     local superStatic = super.static
-    setmetatable(dict, super.__instanceDict)
+    setmetatable(dict, { __index = super.__instanceDict })
     setmetatable(aClass.static, { __index = function(_,k) return rawget(dict,k) or superStatic[k] end })
   else
     setmetatable(aClass.static, { __index = function(_,k) return dict[k] end })
@@ -43,8 +43,9 @@ local function _setClassDictionariesMetatables(aClass)
 end
 
 local all_metamethods_list = { '__add', '__band', '__bor', '__bxor', '__bnot', '__call', '__concat',
-                               '__div', '__eq', '__ipairs', '__idiv', '__le', '__len', '__lt', '__mod',
-                               '__mul', '__pairs', '__pow', '__shl', '__shr', '__sub', '__tostring', '__unm' }
+                               '__div', '__eq', '__gc', '__ipairs', '__idiv', '__le', '__len', '__lt',
+                               '__metatable', '__mod', '__mode', '__mul', '__pairs', '__pow', '__shl',
+                               '__shr', '__sub', '__tostring', '__unm' }
 
 local all_metamethods = {}
 

--- a/middleclass.lua
+++ b/middleclass.lua
@@ -97,7 +97,7 @@ local function _createClass(name, super)
 end
 
 local function _setSubclassMetamethods(aClass, subclass)
-  for m in pairs(aClass.__metamethods) do
+  for m in pairs(all_metamethods) do
     subclass.__instanceDict[m] = aClass.__instanceDict[m]
   end
 end

--- a/spec/metamethods_lua_5_3.lua
+++ b/spec/metamethods_lua_5_3.lua
@@ -6,7 +6,7 @@ local before_each = require('busted').before_each
 local assert = require('busted').assert
 
 describe('Lua 5.3 Metamethods', function()
-  local Vector, a, b
+  local Vector, a, b, last_gc
   before_each(function()
     Vector= class('Vector')
     function Vector.initialize(a,x,y,z) a.x, a.y, a.z = x,y,z end
@@ -21,7 +21,7 @@ describe('Lua 5.3 Metamethods', function()
     end
     function Vector.__len(a)    return 3 end
 
-    function Vector.__gc(a) b.x, b.y, b.z = a.x, a.y, a.z end
+    function Vector.__gc(a) last_gc = {a.class.name, a.x, a.y, a.z} end
     function Vector.__band(a,n) return a.class:new(a.x & n, a.y & n, a.z & n) end
     function Vector.__bor(a,n)  return a.class:new(a.x | n, a.y | n, a.z | n) end
     function Vector.__bxor(a,n) return a.class:new(a.x ~ n, a.y ~ n, a.z ~ n) end
@@ -34,9 +34,10 @@ describe('Lua 5.3 Metamethods', function()
   end)
 
   it('implements __gc', function()
+    collectgarbage()
     a = nil
     collectgarbage()
-    assert.are.same({b.x, b.y, b.z}, {1,2,3})
+    assert.are.same(last_gc, {"Vector",1,2,3})
   end)
 
   it('implements __band', function()
@@ -74,9 +75,10 @@ describe('Lua 5.3 Metamethods', function()
     end)
 
     it('implements __gc', function()
+      collectgarbage()
       c = nil
       collectgarbage()
-      assert.are.same({b.x, b.y, b.z}, {1,2,3})
+      assert.are.same(last_gc, {"Vector2",1,2,3})
     end)
 
     it('implements __band', function()

--- a/spec/metamethods_spec.lua
+++ b/spec/metamethods_spec.lua
@@ -40,6 +40,7 @@ describe('Metamethods', function()
         if type(b)=="number" then return a.class:new(a.x*b, a.y*b, a.z*b) end
         if type(a)=="number" then return b.class:new(a*b.x, a*b.y, a*b.z) end
       end
+      Vector.__metatable = "metatable of a vector"
 
       a = Vector:new(1,2,3)
       b = Vector:new(2,4,6)
@@ -87,6 +88,10 @@ describe('Metamethods', function()
 
     it('implements __mul', function()
       assert.equal(4*a, Vector(4,8,12))
+    end)
+
+    it('implements __metatable', function()
+      assert.equal("metatable of a vector", getmetatable(a))
     end)
 
     --[[
@@ -147,6 +152,10 @@ describe('Metamethods', function()
 
       it('implements __mul', function()
         assert.equal(4*c, Vector2(4,8,12))
+      end)
+
+      it('implements __metatable', function()
+        assert.equal("metatable of a vector", getmetatable(c))
       end)
 
       describe('Updates', function()

--- a/spec/metamethods_spec.lua
+++ b/spec/metamethods_spec.lua
@@ -171,7 +171,6 @@ describe('Metamethods', function()
 
     describe('An instance', function()
       it('has a tostring metamethod, returning a different result from Object.__tostring', function()
-        assert.not_equal(Peter.__tostring, Object.__tostring)
         assert.equal(tostring(peter), 'instance of class Peter')
       end)
     end)

--- a/spec/metamethods_spec.lua
+++ b/spec/metamethods_spec.lua
@@ -148,6 +148,30 @@ describe('Metamethods', function()
       it('implements __mul', function()
         assert.equal(4*c, Vector2(4,8,12))
       end)
+
+      describe('Updates', function()
+        it('overrides __add', function()
+          Vector2.__add = function(a, b) return Vector.__add(a, b)/2 end
+          assert.equal(c+d, Vector2(1.5,3,4.5))
+        end)
+
+        it('updates __add', function()
+          Vector.__add = Vector.__sub
+          assert.equal(c+d, Vector2(-1,-2,-3))
+        end)
+
+        it('does not update __add after overriding', function()
+          Vector2.__add = function(a, b) return Vector.__add(a, b)/2 end
+          Vector.__add = Vector.__sub
+          assert.equal(c+d, Vector2(-0.5,-1,-1.5))
+        end)
+
+        it('reverts __add override', function()
+          Vector2.__add = function(a, b) return Vector.__add(a, b)/2 end
+          Vector2.__add = nil
+          assert.equal(c+d, Vector2(3,6,9))
+        end)
+      end)
     end)
   end)
 

--- a/spec/metamethods_spec.lua
+++ b/spec/metamethods_spec.lua
@@ -41,6 +41,7 @@ describe('Metamethods', function()
         if type(a)=="number" then return b.class:new(a*b.x, a*b.y, a*b.z) end
       end
       Vector.__metatable = "metatable of a vector"
+      Vector.__mode = "k"
 
       a = Vector:new(1,2,3)
       b = Vector:new(2,4,6)
@@ -92,6 +93,12 @@ describe('Metamethods', function()
 
     it('implements __metatable', function()
       assert.equal("metatable of a vector", getmetatable(a))
+    end)
+
+    it('implements __mode', function()
+      a[{}] = true
+      collectgarbage()
+      for k in pairs(a) do assert.not_table(k) end
     end)
 
     --[[
@@ -156,6 +163,12 @@ describe('Metamethods', function()
 
       it('implements __metatable', function()
         assert.equal("metatable of a vector", getmetatable(c))
+      end)
+
+      it('implements __mode', function()
+        c[{}] = true
+        collectgarbage()
+        for k in pairs(c) do assert.not_table(k) end
       end)
 
       describe('Updates', function()

--- a/spec/metamethods_spec.lua
+++ b/spec/metamethods_spec.lua
@@ -171,6 +171,13 @@ describe('Metamethods', function()
         for k in pairs(c) do assert.not_table(k) end
       end)
 
+      it('allows inheriting further', function()
+        local Vector3 = class('Vector3', Vector2)
+        local e = Vector3(1,2,3)
+        local f = Vector3(3,4,5)
+        assert.equal(e+f, Vector3(4,6,8))
+      end)
+
       describe('Updates', function()
         it('overrides __add', function()
           Vector2.__add = function(a, b) return Vector.__add(a, b)/2 end


### PR DESCRIPTION
Alternative inheritable metamethod implementation that doesn't use stubs, instead it intercepts assignments of metamethods and propogates them to child classes manually. Adds support for inheritable `__gc`, `__mode` and `__metatable`. New tests included.

Fixes #32