### PR TITLE
Optimize

### DIFF
--- a/middleclass.lua
+++ b/middleclass.lua
@@ -31,14 +31,22 @@ local middleclass = {
 local function _createIndexWrapper(aClass, f)
   if f == nil then
     return aClass.__instanceDict
-  else
+  elseif type(f) == "function" then
     return function(self, name)
       local value = aClass.__instanceDict[name]
 
       if value ~= nil then
         return value
-      elseif type(f) == "function" then
+      else
         return (f(self, name))
+      end
+    end
+  else -- if  type(f) == "table" then
+    return function(self, name)
+      local value = aClass.__instanceDict[name]
+
+      if value ~= nil then
+        return value
       else
         return f[name]
       end

--- a/middleclass.lua
+++ b/middleclass.lua
@@ -147,7 +147,9 @@ local DefaultMixin = {
       local subclass = _createClass(name, self)
 
       for methodName, f in pairs(self.__instanceDict) do
-        _propagateInstanceMethod(subclass, methodName, f)
+        if not (methodName == "__index" and type(f) == "table") then
+          _propagateInstanceMethod(subclass, methodName, f)
+        end
       end
       subclass.initialize = function(instance, ...) return self.initialize(instance, ...) end
 

--- a/spec/metamethods_spec.lua
+++ b/spec/metamethods_spec.lua
@@ -100,6 +100,10 @@ describe('Metamethods', function()
       for k in pairs(v) do assert.not_table(k) end
     end)
 
+    it('instance should have a table __index if not overrided', function()
+      assert.is_true(type(debug.getmetatable(v).__index) == 'table')
+    end)
+
     --[[
     it('implements __index', function()
       assert.equal(b[1], 3)
@@ -168,6 +172,10 @@ describe('Metamethods', function()
         v2[{}] = true
         collectgarbage()
         for k in pairs(v2) do assert.not_table(k) end
+      end)
+
+      it('instance should also have a table __index if not overrided', function()
+        assert.is_true(type(debug.getmetatable(v2).__index) == 'table')
       end)
 
       it('allows inheriting further', function()


### PR DESCRIPTION
Hello. 
I found that a instance of a subclass always have a functional `__index` metamethod. But if I didn't override it's `__index` metamethod in baseclass, it should be a table. It will be more efficient. I optimized in `fd25b1a`.
And I think conditional branches of a wrapped `__index` metamethod (returned by `_createIndexWrapper()`) could be decreased. I optimized in `63f83ea`.
All of specs are passed.