### PR TITLE
Add pretty-printing to the performance test suite.

### DIFF
--- a/performance/run.lua
+++ b/performance/run.lua
@@ -2,13 +2,17 @@ local class = require 'middleclass'
 
 time = require 'performance/time'
 
-time('class creation', function()
+print("|---------------------------------------------------|")
+print("|              process              |       ms      |")
+print("|---------------------------------------------------|")
+
+time('class creation                   ', function()
   local A = class('A')
 end)
 
 local A = class('A')
 
-time('instance creation', function()
+time('instance creation                ', function()
   local a = A:new()
 end)
 
@@ -18,7 +22,7 @@ end
 
 local a = A:new()
 
-time('instance method invocation', function()
+time('instance method invocation       ', function()
   a:foo()
 end)
 
@@ -26,7 +30,7 @@ local B = class('B', A)
 
 local b = B:new()
 
-time('inherited method invocation', function()
+time('inherited method invocation      ', function()
   b:foo()
 end)
 
@@ -34,10 +38,12 @@ function A.static:bar()
   return 2
 end
 
-time('class method invocation', function()
+time('class method invocation          ', function()
   A:bar()
 end)
 
 time('inherited class method invocation', function()
   B:bar()
 end)
+
+print("|---------------------------------------------------|")

--- a/performance/time.lua
+++ b/performance/time.lua
@@ -1,5 +1,4 @@
 return function(title, f)
-
   collectgarbage()
 
   local startTime = os.clock()
@@ -7,7 +6,6 @@ return function(title, f)
   for i=0,10000 do f() end
 
   local endTime = os.clock()
-
-  print( title, endTime - startTime )
-
+  
+  print(string.format("| %s | %13.9f |", title, (endTime - startTime) * 1e3))
 end


### PR DESCRIPTION
Changed the printing of `performance/*` to display a pretty ASCII-style table. Should work anywhere with a monospace font selected. See results below.

Before:
```
class creation  0.040225
instance creation       0.004141
instance method invocation      0.000528
inherited method invocation     0.000512
class method invocation 0.000554
inherited class method invocation       0.001227

```
After:
```
|---------------------------------------------------|
|              process              |       ms      |
|---------------------------------------------------|
| class creation                    |  40.701000000 |
| instance creation                 |   4.580000000 |
| instance method invocation        |   0.509000000 |
| inherited method invocation       |   0.509000000 |
| class method invocation           |   0.577000000 |
| inherited class method invocation |   1.305000000 |
|---------------------------------------------------|

```
